### PR TITLE
Hotfix/build action of readme to none

### DIFF
--- a/src/Runtime.csproj
+++ b/src/Runtime.csproj
@@ -58,7 +58,7 @@
     <None Include="build\NuGetContentGenerator.targets" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="readme.txt" />
+    <None Include="readme.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/build/NuGetContentGenerator.targets
+++ b/src/build/NuGetContentGenerator.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <AssemblyFile Include="$(SolutionDir)\packages\NuGetContentGenerator.*\tools\NuGetContentGenerator.dll" />
+    <AssemblyFile Include="$(MSBuildThisFileDirectory)..\tools\NuGetContentGenerator.dll" />
   </ItemGroup>
   <UsingTask AssemblyFile="@(AssemblyFile)" TaskName="NuGetContent" />
   <Target Name="TransformNuGetContent" BeforeTargets="Build" Condition="'$(NCrunch)' == ''">

--- a/src/package.nuspec
+++ b/src/package.nuspec
@@ -14,6 +14,7 @@
     <releaseNotes>
         Initial release
     </releaseNotes>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="bin\$configuration$\NuGetContentGenerator.dll" target="tools" />


### PR DESCRIPTION
Changed buildAction of _readme.txt_ to `None`, to fix the output of `nuget pack Runtime.csproj`. Otherwise, _readme.txt_ gets added to _content\\_, when buildAction equals `Content`.