### PR TITLE
set buildAction of "readme.txt" to none

### DIFF
--- a/src/Runtime.csproj
+++ b/src/Runtime.csproj
@@ -58,7 +58,7 @@
     <None Include="build\NuGetContentGenerator.targets" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="readme.txt" />
+    <None Include="readme.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Changed buildAction of _readme.txt_ to `None`, to fix the output of `nuget pack Runtime.csproj`. Otherwise, _readme.txt_ gets added to _content\\_, when buildAction equals `Content`.